### PR TITLE
Allow specifying additional `authorized_keys`

### DIFF
--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -1,6 +1,7 @@
 package linode
 
 import (
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -287,5 +288,39 @@ func TestBuilderPrepare_StateTimeout(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("should have error")
+	}
+}
+
+func TestBuilderPrepare_AuthorizedKeys(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test optional
+	delete(config, "authorized_keys")
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{
+		"ssh-rsa test@test",
+	}
+
+	// Test set
+	config["authorized_keys"] = expected
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if !reflect.DeepEqual(b.config.AuthorizedKeys, expected) {
+		t.Errorf("got %v, expected %v", b.config.AuthorizedKeys, expected)
 	}
 }

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -25,17 +25,17 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Region       string        `mapstructure:"region"`
-	InstanceType string        `mapstructure:"instance_type"`
-	Label        string        `mapstructure:"instance_label"`
-	Tags         []string      `mapstructure:"instance_tags"`
-	Image        string        `mapstructure:"image"`
-	SwapSize     int           `mapstructure:"swap_size"`
-	RootPass     string        `mapstructure:"root_pass"`
-	RootSSHKey   string        `mapstructure:"root_ssh_key"`
-	ImageLabel   string        `mapstructure:"image_label"`
-	Description  string        `mapstructure:"image_description"`
-	StateTimeout time.Duration `mapstructure:"state_timeout" required:"false"`
+	Region         string        `mapstructure:"region"`
+	AuthorizedKeys []string      `mapstructure:"authorized_keys"`
+	InstanceType   string        `mapstructure:"instance_type"`
+	Label          string        `mapstructure:"instance_label"`
+	Tags           []string      `mapstructure:"instance_tags"`
+	Image          string        `mapstructure:"image"`
+	SwapSize       int           `mapstructure:"swap_size"`
+	RootPass       string        `mapstructure:"root_pass"`
+	ImageLabel     string        `mapstructure:"image_label"`
+	Description    string        `mapstructure:"image_description"`
+	StateTimeout   time.Duration `mapstructure:"state_timeout" required:"false"`
 }
 
 func createRandomRootPassword() (string, error) {

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -69,13 +69,13 @@ type FlatConfig struct {
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	PersonalAccessToken       *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
 	Region                    *string           `mapstructure:"region" cty:"region" hcl:"region"`
+	AuthorizedKeys            []string          `mapstructure:"authorized_keys" cty:"authorized_keys" hcl:"authorized_keys"`
 	InstanceType              *string           `mapstructure:"instance_type" cty:"instance_type" hcl:"instance_type"`
 	Label                     *string           `mapstructure:"instance_label" cty:"instance_label" hcl:"instance_label"`
 	Tags                      []string          `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
 	SwapSize                  *int              `mapstructure:"swap_size" cty:"swap_size" hcl:"swap_size"`
 	RootPass                  *string           `mapstructure:"root_pass" cty:"root_pass" hcl:"root_pass"`
-	RootSSHKey                *string           `mapstructure:"root_ssh_key" cty:"root_ssh_key" hcl:"root_ssh_key"`
 	ImageLabel                *string           `mapstructure:"image_label" cty:"image_label" hcl:"image_label"`
 	Description               *string           `mapstructure:"image_description" cty:"image_description" hcl:"image_description"`
 	StateTimeout              *string           `mapstructure:"state_timeout" required:"false" cty:"state_timeout" hcl:"state_timeout"`
@@ -152,13 +152,13 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"linode_token":                 &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"authorized_keys":              &hcldec.AttrSpec{Name: "authorized_keys", Type: cty.List(cty.String), Required: false},
 		"instance_type":                &hcldec.AttrSpec{Name: "instance_type", Type: cty.String, Required: false},
 		"instance_label":               &hcldec.AttrSpec{Name: "instance_label", Type: cty.String, Required: false},
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.List(cty.String), Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"swap_size":                    &hcldec.AttrSpec{Name: "swap_size", Type: cty.Number, Required: false},
 		"root_pass":                    &hcldec.AttrSpec{Name: "root_pass", Type: cty.String, Required: false},
-		"root_ssh_key":                 &hcldec.AttrSpec{Name: "root_ssh_key", Type: cty.String, Required: false},
 		"image_label":                  &hcldec.AttrSpec{Name: "image_label", Type: cty.String, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"state_timeout":                &hcldec.AttrSpec{Name: "state_timeout", Type: cty.String, Required: false},

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -22,13 +22,19 @@ func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) mu
 
 	createOpts := linodego.InstanceCreateOptions{
 		RootPass:       c.Comm.Password(),
-		AuthorizedKeys: []string{string(c.Comm.SSHPublicKey)},
+		AuthorizedKeys: []string{},
 		Region:         c.Region,
 		Type:           c.InstanceType,
 		Label:          c.Label,
 		Image:          c.Image,
 		SwapSize:       &c.SwapSize,
 	}
+
+	if pubKey := string(c.Comm.SSHPublicKey); pubKey != "" {
+		createOpts.AuthorizedKeys = append(createOpts.AuthorizedKeys, pubKey)
+	}
+
+	createOpts.AuthorizedKeys = append(createOpts.AuthorizedKeys, c.AuthorizedKeys...)
 
 	instance, err := s.client.CreateInstance(ctx, createOpts)
 	if err != nil {

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -79,6 +79,8 @@ can also be supplied to override the typical auto-generated key:
 
 ### Optional
 
+- `authorized_keys` (list) - Public SSH keys to be appended to the Linode instance.
+
 - `instance_label` (string) - The name assigned to the Linode Instance.
 
 - `instance_tags` (list) - Tags to apply to the instance when it is created.


### PR DESCRIPTION
Users are currently unable to provision Linode Instances with a predefined public or private key. If `ssh_private_key_file` is specified, the public key will always be set to `nil` and provisioning will fail.

This change allows users to set the `authorized_keys` field exposed by the Linode API, which allows for an Instance to be provisioned with any number of public keys.

For example:
```hcl
source "linode" "example" {
  image             = "linode/alpine3.14"
  image_description = "My Alpine Image."
  image_label       = "packer-alpine"
  instance_label    = "temp-packer-alpine"
  instance_type     = "g6-nanode-1"
  linode_token      = var.linode_token
  region            = "us-east"

  authorized_keys = [chomp(file("/path/to/my/pubkey.pub"))]

  ssh_username      = "root"
  ssh_private_key_file = "/path/to/my/privkey"
}
```

I've also added a quick test to ensure the `authorized_keys` field is handled correctly.

Please let me know if you have any suggestions or more idiomatic solutions to this problem, especially if there is a preferred way to handle this with a communicator! 

Thanks! :smile: 

Closes #18 
