### PR TITLE
Updated all references to an outdated plugin URL in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.0"
-      source  = "github.com/hashicorp/linode"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.0"
-      source  = "github.com/hashicorp/linode"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }
@@ -50,4 +50,3 @@ on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installin
 ### Builders
 
 - [builder](/docs/builders/linode.mdx) - The Linode Builder creates [Linode Images](https://www.linode.com/docs/guides/linode-images/) for use on [Linode](https://www.linode.com/).
-

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -31,7 +31,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 0.0.1"
-      source  = "github.com/hashicorp/linode"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }

--- a/example/basic_linode.pkr.hcl
+++ b/example/basic_linode.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.0"
-      source  = "github.com/hashicorp/linode"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }


### PR DESCRIPTION
Hello, there were several references to a broken URL (`github.com/hashicorp/linode`) in the documentation. I've updated them to be (`github.com/hashicorp/packer-plugin-linode`).