### PR TITLE
Fix the `version` and `source` references for examples in documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     linode = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/linode"
+      version = ">= 1.0.1"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.1"
-      source  = "github.com/hashicorp/packer-plugin-linode"
+      source  = "github.com/hashicorp/linode"
     }
   }
 }

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -30,8 +30,8 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     linode = {
-      version = ">= 0.0.1"
-      source  = "github.com/hashicorp/linode"
+      version = ">= 1.0.1"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -31,7 +31,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.1"
-      source  = "github.com/hashicorp/packer-plugin-linode"
+      source  = "github.com/hashicorp/linode"
     }
   }
 }

--- a/example/basic_linode.pkr.hcl
+++ b/example/basic_linode.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     linode = {
       version = ">= 1.0.1"
-      source  = "github.com/hashicorp/packer-plugin-linode"
+      source  = "github.com/hashicorp/linode"
     }
   }
 }

--- a/example/basic_linode.pkr.hcl
+++ b/example/basic_linode.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
   required_plugins {
     linode = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/linode"
+      version = ">= 1.0.1"
+      source  = "github.com/hashicorp/packer-plugin-linode"
     }
   }
 }


### PR DESCRIPTION
- fixes the plugin source (from github.com/hashicorp/linode to github.com/hashicorp/packer-plugin-linode) in example
- bumped the version in the example since `1.0.1` is the latest release
