### PR TITLE
HCP Packer Support

### DIFF
--- a/builder/linode/artifact.go
+++ b/builder/linode/artifact.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 	"github.com/linode/linodego"
 )
 
@@ -28,6 +29,9 @@ func (a Artifact) String() string {
 }
 
 func (a Artifact) State(name string) interface{} {
+	if name == registryimage.ArtifactStateURI {
+		return a.stateHCPPackerRegistryMetadata()
+	}
 	return a.StateData[name]
 }
 
@@ -35,4 +39,36 @@ func (a Artifact) Destroy() error {
 	log.Printf("Destroying image: %s (%s)", a.ImageID, a.ImageLabel)
 	err := a.Driver.DeleteImage(context.TODO(), a.ImageID)
 	return err
+}
+
+func (a Artifact) stateHCPPackerRegistryMetadata() interface{} {
+	// create labels map
+	labels := make(map[string]string)
+	// get and set sourceImage from stateData into labels
+	sourceImage, ok := a.StateData["source_image"].(string)
+	if ok {
+		labels["source_image"] = sourceImage
+	}
+	// get and set region from stateData into labels
+	region, ok := a.StateData["region"].(string)
+	if ok {
+		labels["region"] = region
+	}
+	// get and set instance_type (specs) from stateData into labels
+	linodeType, ok := a.StateData["linode_type"].(string)
+	if ok {
+		labels["linode_type"] = linodeType
+	}
+	// create the image from artifact
+	image, err := registryimage.FromArtifact(a,
+		registryimage.WithProvider("Linode"),
+		registryimage.WithID(a.ImageID),
+		registryimage.WithSourceID(sourceImage),
+		registryimage.WithRegion(region))
+	if err != nil {
+		log.Printf("[DEBUG] error encountered when creating registry image %s", err)
+		return nil
+	}
+	image.Labels = labels
+	return image
 }

--- a/builder/linode/artifact.go
+++ b/builder/linode/artifact.go
@@ -61,7 +61,7 @@ func (a Artifact) stateHCPPackerRegistryMetadata() interface{} {
 	}
 	// create the image from artifact
 	image, err := registryimage.FromArtifact(a,
-		registryimage.WithProvider("Linode"),
+		registryimage.WithProvider("linode"),
 		registryimage.WithID(a.ImageID),
 		registryimage.WithSourceID(sourceImage),
 		registryimage.WithRegion(region))

--- a/builder/linode/artifact_test.go
+++ b/builder/linode/artifact_test.go
@@ -90,7 +90,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 	// check that all properties of the images were set correctly
 	expected := registryimage.Image{
 		ImageID:        "test-image",
-		ProviderName:   "Linode",
+		ProviderName:   "linode",
 		ProviderRegion: "us-east",
 		SourceImageID:  "linode/debian9",
 		Labels: map[string]string{

--- a/builder/linode/artifact_test.go
+++ b/builder/linode/artifact_test.go
@@ -1,9 +1,12 @@
 package linode
 
 import (
+	"reflect"
 	"testing"
 
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
+	"github.com/mitchellh/mapstructure"
 )
 
 func TestArtifact_Impl(t *testing.T) {
@@ -57,5 +60,46 @@ func TestArtifactState_StateData(t *testing.T) {
 	result = artifact.State("key")
 	if result != nil {
 		t.Fatalf("Bad: State should be nil for nil StateData")
+	}
+}
+
+func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
+	region := "us-east"
+	artifact := &Artifact{
+		ImageID:    "test-image",
+		ImageLabel: "test-image-label",
+		StateData: map[string]interface{}{
+			"source_image": "linode/debian9",
+			"region":       region,
+			"linode_type":  "g6-nanode-1",
+		},
+	}
+	// result should contain "something"
+	result := artifact.State(registryimage.ArtifactStateURI)
+	if result == nil {
+		t.Fatalf("Bad: HCP Packer registry image data was nil")
+	}
+
+	// check for proper decoding of result into slice of registryimage.Image
+	var image registryimage.Image
+	err := mapstructure.Decode(result, &image)
+	if err != nil {
+		t.Errorf("Bad: unexpected error when trying to decode state into registryimage.Image %v", err)
+	}
+
+	// check that all properties of the images were set correctly
+	expected := registryimage.Image{
+		ImageID:        "test-image",
+		ProviderName:   "Linode",
+		ProviderRegion: "us-east",
+		SourceImageID:  "linode/debian9",
+		Labels: map[string]string{
+			"source_image": "linode/debian9",
+			"region":       region,
+			"linode_type":  "g6-nanode-1",
+		},
+	}
+	if !reflect.DeepEqual(image, expected) {
+		t.Fatalf("Bad: expected %#v got %#v", expected, image)
 	}
 }

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -95,7 +95,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		ImageLabel: image.Label,
 		ImageID:    image.ID,
 		Driver:     &client,
-		StateData:  map[string]interface{}{"generated_data": state.Get("generated_data")},
+		StateData: map[string]interface{}{
+			"generated_data": state.Get("generated_data"),
+			"source_image":   b.config.Image,
+			"region":         b.config.Region,
+			"linode_type":    b.config.InstanceType,
+		},
 	}
 
 	return artifact, nil

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -33,7 +33,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	if errs != nil {
 		return nil, warnings, errs
 	}
-	return nil, nil, nil
+	return nil, warnings, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (ret packersdk.Artifact, err error) {

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,79 @@
+# Examples
+
+## Simple Packer Build
+
+After cloning this repo, move to the `example` directory by running:
+
+```shell
+cd packer-plugin-linode/example
+```
+
+Either modify `basic_linode.pkr.hcl` to reflect your Linode token or comment that out and set the `LINODE_TOKEN` environment variable by running:
+
+```shell
+export LINODE_TOKEN=<your linode token>
+```
+
+Then run the following commands to build a simple Linode image via Packer:
+
+```shell
+packer init basic_linode.pkr.hcl
+packer build basic_linode.pkr.hcl
+```
+
+## HCP Packer Build
+
+### Prerequisites
+
+- In order to complete this example, you must have Packer and Terraform installed.
+
+HCP Packer gives users the ability to store metadata about their Packer builds and have Terraform consume the image IDs from HCP Packer to deploy virtual machines with that specific image. Learn more about HCP Packer [here](https://cloud.hashicorp.com/docs/packer).
+
+After cloning this repo move to the `example` directory by running:
+
+```shell
+cd packer-plugin-linode/example
+```
+
+HCP Packer requires a HCP account and the creation of a service principal. Documentation on creating a service principal can be found [here](https://cloud.hashicorp.com/docs/hcp/access-control/service-principals).
+
+Once your service principal is created, either modify `hcp_packer_linode.pkr.hcl` to reflect your Linode token or comment those lines out and run the following to set the `LINODE_TOKEN`:
+
+```shell
+export LINODE_TOKEN=<your linode token>
+```
+
+Then run the following commands to build a simple Linode image via Packer and store the metadata about that image in HCP:
+
+```shell
+packer init hcp_packer_linode.pkr.hcl
+packer build hcp_packer_linode.pkr.hcl
+```
+
+Now the metadata about your Linode image is stored within HCP Packer.
+
+### Deploy Linode Instance with Terraform
+
+Navigate to your HCP Packer bucket `linode-hcp-test` in a web browser.
+
+Under `channels` create a new channel named `production` and assign the most recent iteration to it.
+
+Back in your terminal navigate to the `example` directory by running:
+```shell
+cd packer-plugin-linode/example
+```
+
+Modify the `linode` and `hcp` provider blocks within the Terraform file `main.tf` with Linode Token, HCP Client ID, and HCP Client Secret or comment those lines out and run the following to set the `LINODE_TOKEN`, `HCP_CLIENT_ID`, and `HCP_CLIENT_SECRET` environment variables:
+
+```shell
+export LINODE_TOKEN=<your linode token>
+export HCP_CLIENT_ID=<your HCP client ID>
+export HCP_CLIENT_SECRET=<your HCP client secret>
+```
+
+In order to deploy the Linode instance using the image based on HCP Packer metadata run the following commands:
+
+```shell
+terraform init
+terraform apply
+```

--- a/example/hcp_packer_linode.pkr.hcl
+++ b/example/hcp_packer_linode.pkr.hcl
@@ -1,0 +1,32 @@
+packer {
+  required_plugins {
+    linode = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/linode"
+    }
+  }
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "linode" "example" {
+  linode_token      = "Your Personal Access Token"
+  image             = "linode/debian9"
+  image_description = "My Private Image"
+  image_label       = "private-image-${local.timestamp}"
+  instance_label    = "temporary-linode-${local.timestamp}"
+  instance_type     = "g6-nanode-1"
+  region            = "us-east"
+  ssh_username      = "root"
+}
+
+build {
+  hcp_packer_registry {
+    bucket_name = "linode-hcp-test"
+    description = "A nice test description"
+    bucket_labels = {
+      "foo" = "bar"
+    }
+  }
+  sources = ["source.linode.example"]
+}

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "1.26.1"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "0.24.0"
+    }
+  }
+}
+
+// either use "token" below or set LINODE_TOKEN ENV VAR
+provider "linode" {
+  token = "YOUR LINODE TOKEN"
+}
+
+// either set the below values or
+// set HCP_CLIENT_ID and HCP_CLIENT_SECRET
+provider "hcp" {
+  client_id = "YOUR HCP CLIENT ID"
+  client_secret = "YOUR HCP CLIENT SECRET"
+}
+
+data "hcp_packer_iteration" "production_linode" {
+  bucket_name = "linode-hcp-test"
+  channel     = "production"
+}
+
+data "hcp_packer_image" "production_linode_image" {
+  bucket_name    = "linode-hcp-test"
+  cloud_provider = "linode"
+  iteration_id   = data.hcp_packer_iteration.production_linode.ulid
+  region         = "us-east"
+}
+
+resource "linode_instance" "production_linode_instance" {
+  label           = "test-hcp-linode-instance"
+  image           = data.hcp_packer_image.production_linode_image.cloud_image_id
+  region          = "us-east"
+  type            = "g6-nanode-1"
+  root_pass       = "terr4form_test"
+}


### PR DESCRIPTION
This adds the ability to interact with HCP Packer from within the Linode Packer plugin. Tests are included as well as an example Packer file.