### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -44,7 +44,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 
@@ -89,7 +89,7 @@ can also be supplied to override the typical auto-generated key:
 
 - `image_label` (string) - The name of the resulting image that will appear
   in your account. Defaults to `packer-{{timestamp}}` (see [configuration
-  templates](/docs/templates/legacy_json_templates/engine) for more info).
+  templates](/packer/docs/templates/legacy_json_templates/engine) for more info).
 
 - `image_description` (string) - The description of the resulting image that
   will appear in your account. Defaults to "".


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them